### PR TITLE
Force file extensions on local imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,7 @@
+const BASE_CONFIG = require('@andrao/eslint/lib/base');
+
+module.exports = {
+    ...BASE_CONFIG,
+    extends: [...BASE_CONFIG.extends, 'plugin:require-extensions/recommended'],
+    plugins: [...BASE_CONFIG.plugins, 'require-extensions'],
+};

--- a/examples/messaging.ts
+++ b/examples/messaging.ts
@@ -1,5 +1,5 @@
-import { PlanetScaleMessagingStream } from '../src/PlanetScaleMessagingStream';
-import { env } from './_common/env';
+import { PlanetScaleMessagingStream } from '../src/PlanetScaleMessagingStream.js';
+import { env } from './_common/env.js';
 
 /**
  * @todo Set DB config in .env file

--- a/examples/vstream.ts
+++ b/examples/vstream.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import chalk from 'chalk';
-import { PlanetScaleVStream } from '../src/PlanetScaleVStream';
-import { env } from './_common/env';
+import { PlanetScaleVStream } from '../src/PlanetScaleVStream/index.js';
+import { env } from './_common/env.js';
 
 /**
  * @todo Set DB config in .env file

--- a/package.json
+++ b/package.json
@@ -41,10 +41,6 @@
         "vstream": "tsx ./examples/vstream.ts"
     },
     "prettier": "@andrao/prettier",
-    "eslintConfig": {
-        "extends": "./node_modules/@andrao/eslint/lib/base.js",
-        "root": true
-    },
     "release": {
         "branches": [
             "main",
@@ -92,6 +88,7 @@
         "@types/node": "20.12.2",
         "chalk": "4.1.2",
         "dotenv": "16.4.5",
+        "eslint-plugin-require-extensions": "0.1.3",
         "semantic-release": "23.0.6",
         "tsx": "4.19.1",
         "typescript": "5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
+      eslint-plugin-require-extensions:
+        specifier: 0.1.3
+        version: 0.1.3(eslint@8.57.1)
       semantic-release:
         specifier: 23.0.6
         version: 23.0.6(typescript@5.7.3)
@@ -1535,6 +1538,12 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-require-extensions@0.1.3:
+    resolution: {integrity: sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      eslint: '*'
 
   eslint-plugin-storybook@0.6.15:
     resolution: {integrity: sha512-lAGqVAJGob47Griu29KXYowI4G7KwMoJDOkEip8ujikuDLxU+oWJ1l0WL6F2oDO4QiyUFXvtDkEkISMOPzo+7w==}
@@ -5202,6 +5211,10 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-require-extensions@0.1.3(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
 
   eslint-plugin-storybook@0.6.15(eslint@8.57.1)(typescript@5.7.3):
     dependencies:

--- a/src/PlanetScaleMessagingStream.ts
+++ b/src/PlanetScaleMessagingStream.ts
@@ -11,12 +11,12 @@ import {
     type Field,
 } from '@buf/planetscale_vitess.bufbuild_es/vitess/query/v19/query_pb';
 import { create } from '@bufbuild/protobuf';
-import { parseQueryResult } from './_common/parseQueryResult';
+import { parseQueryResult } from './_common/parseQueryResult/index.js';
 import {
     createPsdbV1Alpha1DatabaseClient,
     type DatabaseClient,
     type PlanetScaleDatabaseConnectConfig,
-} from './clients/createPsdbV1Alpha1DatabaseClient';
+} from './clients/createPsdbV1Alpha1DatabaseClient.js';
 
 interface IPlanetScaleMessagingStreamConstructor<PK extends string> {
     /** @description PlanetScale database config */

--- a/src/PlanetScaleVStream/index.ts
+++ b/src/PlanetScaleVStream/index.ts
@@ -8,8 +8,8 @@ import {
     createPsdbConnectV1Alpha1Client,
     type IConnectClient,
     type PlanetScaleConnectConfig,
-} from '../clients/createPsdbConnectV1Alpha1Client';
-import { parseResponse } from './parseResponse';
+} from '../clients/createPsdbConnectV1Alpha1Client.js';
+import { parseResponse } from './parseResponse.js';
 
 interface IPlanetScaleVStreamConstructor {
     /** @description PlanetScale database config */

--- a/src/PlanetScaleVStream/parseResponse.ts
+++ b/src/PlanetScaleVStream/parseResponse.ts
@@ -4,7 +4,7 @@ import {
     type UpdatedRow,
 } from '@buf/planetscale_psdb.bufbuild_es/psdbconnect/v1alpha1/connect_pb';
 import { type QueryResult } from '@buf/planetscale_vitess.bufbuild_es/vitess/query/v19/query_pb';
-import { parseQueryResult } from '../_common/parseQueryResult';
+import { parseQueryResult } from '../_common/parseQueryResult/index.js';
 
 /**
  * @description Parses the response from the PlanetScale sync stream

--- a/src/_common/parseQueryResult/index.ts
+++ b/src/_common/parseQueryResult/index.ts
@@ -1,7 +1,7 @@
 import type { QueryResult } from '@buf/planetscale_vitess.bufbuild_es/vitess/query/v19/query_pb';
-import { parseVitessRecord } from './parseVitessRecord';
-import { proto3ToRows } from './proto3ToRows';
-import { queryResultToRecords } from './queryResultToRecords';
+import { parseVitessRecord } from './parseVitessRecord.js';
+import { proto3ToRows } from './proto3ToRows.js';
+import { queryResultToRecords } from './queryResultToRecords.js';
 
 /**
  * @description Parses a query result into JS records

--- a/src/_common/parseQueryResult/parseValue.ts
+++ b/src/_common/parseQueryResult/parseValue.ts
@@ -1,4 +1,4 @@
-import type { Value } from './proto3ToRows';
+import type { Value } from './proto3ToRows.js';
 
 /**
  * @description Parses a value based on its column type

--- a/src/_common/parseQueryResult/queryResultToRecords.ts
+++ b/src/_common/parseQueryResult/queryResultToRecords.ts
@@ -1,6 +1,6 @@
 import { type Field } from '@buf/planetscale_vitess.bufbuild_es/vitess/query/v19/query_pb';
-import { parseValue } from './parseValue';
-import type { Value } from './proto3ToRows';
+import { parseValue } from './parseValue.js';
+import type { Value } from './proto3ToRows.js';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from './PlanetScaleMessagingStream';
-export * from './PlanetScaleVStream';
+export * from './PlanetScaleMessagingStream.js';
+export * from './PlanetScaleVStream/index.js';


### PR DESCRIPTION
## Summary
This PR introduces the [eslint-plugin-require-extensions](https://github.com/anza-xyz/eslint-plugin-require-extensions) rule to the repo, which forces use of the `.js` extension on local imports.

Closes #3.